### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ project(AstmPhantomTest)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://www.atracsys-measurement.com/astm/")
 set(EXTENSION_CATEGORY "IGT")
-set(EXTENSION_CONTRIBUTORS "Sylvain Bernhardt, Atracsys LLC")
+set(EXTENSION_CONTRIBUTORS "Sylvain Bernhardt (Atracsys LLC)")
 set(EXTENSION_DESCRIPTION "This extension for 3D Slicer is an assistant in performing the accuracy test of a tracking system as described in the ASTM standard F2554.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/Atracsys/SlicerAstmPhantomTest/master/SlicerAstmPhantomTest.png")
-set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/Atracsys/SlicerAstmPhantomTest/master/screenshots/screenshot1.png https://raw.githubusercontent.com/Atracsys/SlicerAstmPhantomTest/master/screenshots/screenshot2.png https://raw.githubusercontent.com/Atracsys/astm-phantom-test/master/screenshots/screenshot3.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/Atracsys/SlicerAstmPhantomTest/master/screenshots/screenshot1.png https://raw.githubusercontent.com/Atracsys/SlicerAstmPhantomTest/master/screenshots/screenshot2.png https://raw.githubusercontent.com/Atracsys/SlicerAstmPhantomTest/master/screenshots/screenshot3.png")
 set(EXTENSION_DEPENDS "SlicerOpenIGTLink")
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.